### PR TITLE
Update Go version to v1.21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.16'
+        go-version: '1.21'
 
     - name: Get dependencies
       run: go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pgeu/pgeu-meetingserver
 
-go 1.16
+go 1.21
 
 require (
 	github.com/gorilla/websocket v1.4.2


### PR DESCRIPTION
According to the [release policy](https://go.dev/doc/devel/release#policy):
> Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release.

Latest go1.16.15 was released 2022-03-03. This PR bumps Go version to the latest v1.21